### PR TITLE
Limit syslog.go build to unix-like OSes.

### DIFF
--- a/syslog.go
+++ b/syslog.go
@@ -1,3 +1,5 @@
+// +build linux darwin freebsd netbsd openbsd !windows
+
 package distillog
 
 import (


### PR DESCRIPTION
Otherwise building / cross-building for Windows fails.
